### PR TITLE
Use the same selector as was mentioned in the markup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For instance:
 
 		<script src='./dropcap.min.js'></script>
 		<script>
-			var dropcaps = document.querySelectorAll(".drop-cap");
+			var dropcaps = document.querySelectorAll(".dropcap");
     		window.Dropcap.layout(dropcaps, 3);
     	</script>
 		


### PR DESCRIPTION
The markup uses the `dropcap` class, but the js uses `drop-cap` which might cause issues for copy pasters :)
