### PR TITLE
Update demo link to point to gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dropcap.js
 ===========
 
-dropcap.js makes beautiful drop caps easy for the web. Try it out at [http://webplatform.adobe.com/dropcap.js/](http://webplatform.adobe.com/dropcap.js/)
+dropcap.js makes beautiful drop caps easy for the web. Try it out at [https://adobe-webplatform.github.io/dropcap.js/](https://adobe-webplatform.github.io/dropcap.js/)
 
 ## Why
 Though drop caps are very common in magazines and books, they remain rare on the web. We believe this is because doing it right simply and reliably is too difficult. A simple CSS float:left on a ::first-letter pseudo-element is not enough, as this [tumblr][tumblr] shows. This [blog post][blog] explains some of the challenges of defining drop caps in CSS today.


### PR DESCRIPTION
There's also a link field in the header of the repository would be helpful to populate with the same link: https://adobe-webplatform.github.io/dropcap.js/